### PR TITLE
Fix grammar in weekly e-mail report

### DIFF
--- a/src/sentry/templates/sentry/emails/reports/body.html
+++ b/src/sentry/templates/sentry/emails/reports/body.html
@@ -544,7 +544,7 @@
           <h4>3 Month History</h4>
         </th>
         <td class="spectrum" style="vertical-align: bottom;">
-          Less Events
+          Fewer Events
           <div class="range">{% for color in report.calendar.legend %}<span style="background-color: {{ color }}">&nbsp;</span>{% endfor %}</div>
           More Events
         </td>


### PR DESCRIPTION
Follow-up of #4993 which already explains why "less" is incorrect and "fewer" is correct.